### PR TITLE
Bugfix/fix timer at date

### DIFF
--- a/src/james/jamesutils.py
+++ b/src/james/jamesutils.py
@@ -187,13 +187,13 @@ class JamesUtils(object):
         return (hours * 3600 + minutes * 60 + int(seconds))
 
     def date_string2values(self, arg):
-        # converts dd-mm-yyyy into [yyyy, mm, dd]
+        # converts yyyy-mm-dd into [yyyy, mm, dd]
         try:
             data = arg.split('-')
-            if int(data[0]) > 0 and int(data[0]) < 13:
-                if int(data[1]) > 0 and int(data[1]) < 32:
-                    if int(data[2]) > 2012:
-                        return [int(data[2]), int(data[1]), int(data[0])]
+            if int(data[0]) > 2020:
+                if int(data[1]) > 0 and int(data[1]) < 13:
+                    if int(data[2]) > 0 and int(data[2]) < 32:
+                        return [int(data[0]), int(data[1]), int(data[2])]
         except Exception as e:
             return False
 

--- a/src/james/plugin/timer.py
+++ b/src/james/plugin/timer.py
@@ -14,7 +14,7 @@ class TimerPlugin(Plugin):
     def __init__(self, core, descriptor):
         super(TimerPlugin, self).__init__(core, descriptor)
 
-        self.commands.create_subcommand('at', 'Runs a command at given time (hh:mm[:ss] [dd-mm-yyyy])', self.cmd_timer_at)
+        self.commands.create_subcommand('at', 'Runs a command at given time (hh:mm[:ss] [yyyy-mm-dd])', self.cmd_timer_at)
         self.commands.create_subcommand('remove', 'Delets a command (id)', self.cmd_timer_remove)
         self.commands.create_subcommand('in', 'Runs a command in given time (sec|1s2m3h4d5w)', self.cmd_timer_in)
         self.commands.create_subcommand('show', 'Returns a list of commands', self.cmd_timer_show)


### PR DESCRIPTION
Since the date order for `mcp at` was wrong anyways in the helptext to the `date_string2values` method, it is changed to be more "international" by choosing the logical order. 